### PR TITLE
Legacy SDK: Populate Morpheus Respose object before error checking

### DIFF
--- a/legacy/client.go
+++ b/legacy/client.go
@@ -362,29 +362,6 @@ func (client *Client) Execute(req *Request) (*Response, error) {
 	}
 
 	httpResp, err := client.HTTPClient.Do(httpReq)
-
-	receivedTime := time.Now()
-	httpRespBody, err := io.ReadAll(httpResp.Body)
-	if err != nil {
-		return nil, err
-	}
-	defer httpResp.Body.Close()
-
-	// Convert a net/http response into a Morpheus Response object
-	// Do this before error checking so we can return a Morpheus Response
-	// with useful information.
-	// Having the resp information availble regardless of failure is how the
-	// client behaved before we switched from the Resty Client to net/http client.
-	resp = &Response{
-		Success:      httpResp.StatusCode > 199 && httpResp.StatusCode < 300,
-		StatusCode:   httpResp.StatusCode,
-		Status:       httpResp.Status,
-		ReceivedAt:   receivedTime,
-		Size:         int64(len(httpRespBody)), // This is the same as what Resty does
-		Body:         httpRespBody,
-		HTTPResponse: httpResp,
-	}
-
 	if httpResp == nil || httpResp.StatusCode != http.StatusOK || err != nil {
 		// standardize the error format across both providers
 		return resp, errWithBody(err, httpResp)
@@ -400,6 +377,24 @@ func (client *Client) Execute(req *Request) (*Response, error) {
 		log.Printf("\nRESPONSE:\n%s\n", string(dump))
 	}
 
+	receivedTime := time.Now()
+
+	httpRespBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, err
+	}
+	defer httpResp.Body.Close()
+
+	// Convert a net/http response into a Morpheus Response object
+	resp = &Response{
+		Success:    httpResp.StatusCode > 199 && httpResp.StatusCode < 300,
+		StatusCode: httpResp.StatusCode,
+		Status:     httpResp.Status,
+		ReceivedAt: receivedTime,
+		Size:       int64(len(httpRespBody)), // This is the same as what Resty does
+		Body:       httpRespBody,
+	}
+
 	if client.errCallbackFunc != nil {
 		customErr := client.errCallbackFunc(err)
 		// only use non-nil errors
@@ -407,6 +402,8 @@ func (client *Client) Execute(req *Request) (*Response, error) {
 			return resp, customErr
 		}
 	}
+
+	resp.HTTPResponse = httpResp
 
 	// attempt to parse as json, populates JsonData
 	var parsedResult interface{}

--- a/legacy/client.go
+++ b/legacy/client.go
@@ -362,6 +362,29 @@ func (client *Client) Execute(req *Request) (*Response, error) {
 	}
 
 	httpResp, err := client.HTTPClient.Do(httpReq)
+
+	receivedTime := time.Now()
+	httpRespBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, err
+	}
+	defer httpResp.Body.Close()
+
+	// Convert a net/http response into a Morpheus Response object
+	// Do this before error checking so we can return a Morpheus Response
+	// with useful information.
+	// Having the resp information availble regardless of failure is how the
+	// client behaved before we switched from the Resty Client to net/http client.
+	resp = &Response{
+		Success:      httpResp.StatusCode > 199 && httpResp.StatusCode < 300,
+		StatusCode:   httpResp.StatusCode,
+		Status:       httpResp.Status,
+		ReceivedAt:   receivedTime,
+		Size:         int64(len(httpRespBody)), // This is the same as what Resty does
+		Body:         httpRespBody,
+		HTTPResponse: httpResp,
+	}
+
 	if httpResp == nil || httpResp.StatusCode != http.StatusOK || err != nil {
 		// standardize the error format across both providers
 		return resp, errWithBody(err, httpResp)
@@ -377,24 +400,6 @@ func (client *Client) Execute(req *Request) (*Response, error) {
 		log.Printf("\nRESPONSE:\n%s\n", string(dump))
 	}
 
-	receivedTime := time.Now()
-
-	httpRespBody, err := io.ReadAll(httpResp.Body)
-	if err != nil {
-		return nil, err
-	}
-	defer httpResp.Body.Close()
-
-	// Convert a net/http response into a Morpheus Response object
-	resp = &Response{
-		Success:    httpResp.StatusCode > 199 && httpResp.StatusCode < 300,
-		StatusCode: httpResp.StatusCode,
-		Status:     httpResp.Status,
-		ReceivedAt: receivedTime,
-		Size:       int64(len(httpRespBody)), // This is the same as what Resty does
-		Body:       httpRespBody,
-	}
-
 	if client.errCallbackFunc != nil {
 		customErr := client.errCallbackFunc(err)
 		// only use non-nil errors
@@ -402,8 +407,6 @@ func (client *Client) Execute(req *Request) (*Response, error) {
 			return resp, customErr
 		}
 	}
-
-	resp.HTTPResponse = httpResp
 
 	// attempt to parse as json, populates JsonData
 	var parsedResult interface{}

--- a/legacy/client.go
+++ b/legacy/client.go
@@ -362,9 +362,11 @@ func (client *Client) Execute(req *Request) (*Response, error) {
 	}
 
 	httpResp, err := client.HTTPClient.Do(httpReq)
-	if httpResp == nil || httpResp.StatusCode != http.StatusOK || err != nil {
-		// standardize the error format across both providers
-		return resp, errWithBody(err, httpResp)
+	if httpResp == nil || err != nil {
+		if httpResp == nil {
+			return resp, errors.New("nil HTTP response")
+		}
+		return resp, err
 	}
 
 	// Dump the response if debug is enabled.
@@ -380,19 +382,23 @@ func (client *Client) Execute(req *Request) (*Response, error) {
 	receivedTime := time.Now()
 
 	httpRespBody, err := io.ReadAll(httpResp.Body)
+	httpResp.Body.Close()
+	// we need the body available for a second read for returning
+	// formatted errs in non-success cases.
+	httpResp.Body = io.NopCloser(bytes.NewReader(httpRespBody))
 	if err != nil {
 		return nil, err
 	}
-	defer httpResp.Body.Close()
 
 	// Convert a net/http response into a Morpheus Response object
 	resp = &Response{
-		Success:    httpResp.StatusCode > 199 && httpResp.StatusCode < 300,
-		StatusCode: httpResp.StatusCode,
-		Status:     httpResp.Status,
-		ReceivedAt: receivedTime,
-		Size:       int64(len(httpRespBody)), // This is the same as what Resty does
-		Body:       httpRespBody,
+		Success:      httpResp.StatusCode > 199 && httpResp.StatusCode < 300, // This is what Resty considers a success.
+		StatusCode:   httpResp.StatusCode,
+		Status:       httpResp.Status,
+		ReceivedAt:   receivedTime,
+		Size:         int64(len(httpRespBody)), // This is the same as what Resty does
+		Body:         httpRespBody,
+		HTTPResponse: httpResp,
 	}
 
 	if client.errCallbackFunc != nil {
@@ -402,8 +408,6 @@ func (client *Client) Execute(req *Request) (*Response, error) {
 			return resp, customErr
 		}
 	}
-
-	resp.HTTPResponse = httpResp
 
 	// attempt to parse as json, populates JsonData
 	var parsedResult interface{}
@@ -449,7 +453,13 @@ func (client *Client) Execute(req *Request) (*Response, error) {
 
 	client.incrementRequests(req, resp)
 
-	return resp, err
+	// so we can still access the Morpheus Resp body in non-success cases
+	if !resp.Success {
+		return resp, errWithBody(errors.New("failed"), httpResp)
+	}
+
+	// success
+	return resp, nil
 }
 
 func (client *Client) Get(req *Request) (*Response, error) {


### PR DESCRIPTION
This fixes some issues with our polling code.

When we refactored to no longer use the Resty client, we accidentally changed a core behaviour of the SDK's Execute method.

Previously, it would always return `resp, err`, with resp being populated, even in failure.
With the refactor, on non-200 status codes or other `net/http` client errors, `resp` would be not yet populated.

This effectively maintains the behaviour of the client before we switched to `net/http` client, while keeping the same
error reporting and handling mechanisms as the OpenAPI Generator client.
